### PR TITLE
Added Jenkins GitHub Pull Request Builder support

### DIFF
--- a/lib/jenkins/examples/ghprb.json
+++ b/lib/jenkins/examples/ghprb.json
@@ -1,0 +1,34 @@
+{
+  "headers": {},
+  "body": {
+    "name": "webhooks-handler",
+    "url": "job/webhooks-handler/",
+    "build": {
+      "full_url": "http://example.com/job/webhooks-handler/123/",
+      "number": 123,
+      "phase": "STARTED",
+      "url": "job/webhooks-handler/123/",
+      "scm": {
+        "url": "https://github.com/example/webhooks-handler.git",
+        "branch": "pr-branch",
+        "commit": "b7efe268c0a8cf53800ff6ea871b7dbe405f1401"
+      },
+      "parameters": {
+        "ghprbTriggerAuthorEmail": "",
+        "ghprbTargetBranch": "master",
+        "ghprbSourceBranch": "br-branch",
+        "ghprbActualCommitAuthor": "John Doe",
+        "ghprbPullLink": "https://github.com/example/webhooks-handler/pull/456",
+        "ghprbActualCommit": "02b80968e1c06580f32e05e4db91b4c067519fa5",
+        "ghprbPullAuthorEmail": "johndoe@example.com",
+        "ghprbTriggerAuthor": "John Doe",
+        "ghprbActualCommitAuthorEmail": "johndoe@example.com",
+        "ghprbPullId": "456",
+        "ghprbPullTitle": "Made some changes",
+        "ghprbPullDescription": "GitHub pull request #456 of commit 02b80968e1c06580f32e05e4db91b4c067519fa5 automatically merged."
+      },
+      "log": "did all the things",
+      "artifacts": {}
+    }
+  }
+}

--- a/lib/jenkins/index.js
+++ b/lib/jenkins/index.js
@@ -29,8 +29,21 @@ var parse = function(headers, body, settings) {
   // our statusMessage can be [started, success, failure]
   var statusMessage = status || phase;
 
+  // check if the GitHub pull request builder has added a pull request
+  var parameters = build.parameters;
+  var prMessage = '';
+  if(parameters) {
+    var link = parameters.ghprbPullLink;
+    if(link) {
+      var match = new RegExp('.*/([^/]+/[^/]+)/pull/([0-9]+)').exec(link);
+      if(match) {
+        prMessage = ' for ['+match[1]+'#'+match[2]+']('+link+')';
+      }
+    }
+  }
+
   // creating the markdown
-  var message = 'Jenkins ['+body.name+']('+build.full_url+') '+statusMessage;
+  var message = 'Jenkins ['+body.name+']('+build.full_url+') '+statusMessage+prMessage;
 
   // this is the name of the file in the "icons" folder
   var icon = 'smile';

--- a/lib/jenkins/test/index.js
+++ b/lib/jenkins/test/index.js
@@ -93,4 +93,16 @@ describe('Jenkins', function() {
     assert.equal(response, undefined);
   });
 
+  it('should include the GitHub PR link if present', function() {
+    var payload = examples['ghprb'];
+    var settings = {
+      events: {
+        started: true
+      }
+    };
+    
+    var response = parse(payload.headers, payload.body, settings);
+    assert.equal(response.message, 'Jenkins [webhooks-handler](http://example.com/job/webhooks-handler/123/) started for [example/webhooks-handler#456](https://github.com/example/webhooks-handler/pull/456)');
+  });
+
 });


### PR DESCRIPTION
The Jenkins GitHub Pull Request Builder adds meta data to the Jenkins notification webhook about which pull request was being built. This renders that meta data in the activity message.

Tested with playground against a live Jenkins with the pull request builder enabled:

![localhost_3333_jenkins](https://cloud.githubusercontent.com/assets/105833/7508478/4c03ee18-f4c4-11e4-9f93-85dfd077eac6.png)