### PR TITLE
Fix Travis instructions

### DIFF
--- a/lib/travis/instructions.md
+++ b/lib/travis/instructions.md
@@ -8,5 +8,5 @@ notifications:
       - YOUR_WEBHOOK_URL
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_start: never     # options: [always|never|change] default: always
 ```


### PR DESCRIPTION
According to http://docs.travis-ci.com/user/notifications/#Webhook-notification, the possible values for `on_start` are `always`, `never` or `change`. The previous default value `false` is invalid and gets rejected by `travis lint`:

```
$ travis lint
[x] in notifications.webhooks section: dropping on_start section: illegal value false
```
This patch simply replaces `on_start: false` with `on_start: never` and displays all options (just like `on_success` and `on_failure`).