### PR TITLE
Update Coveralls instructions

### DIFF
--- a/lib/coveralls/instructions.md
+++ b/lib/coveralls/instructions.md
@@ -1,4 +1,11 @@
-Setup your Coveralls repo web hook notification settings by going to...
-```
-https://coveralls.io/<username>/<yourrepo>/notifications/webhook
-```
+[Coveralls](https://coveralls.io) is a web service to help you track your code coverage over time, ensure that all your new code is fully covered, and gain insight into where your code is vulnerable to bugs.
+
+To set up your repo web hook notification, do the following:
+
+1. Navigate to [your list of Repositories](https://coveralls.io/repos).
+2. Select the repository that you want to add Gitter notification to.
+3. Click the Notifications button.
+4. Click the Configure button next to "Gitter".
+5. Paste your webhook URL from below.
+6. Hit Test and see it work.
+7. Finally, save the notification.


### PR DESCRIPTION
Coveralls now includes a Gitter notification option, so I've updated the instructions to use it. The previous instructions had a URL that was deprecated anyway, so this should be an improvement over having users piece together their own URL.

![coveralls notifications showing gitter](https://cloud.githubusercontent.com/assets/1005280/16160846/566722de-3498-11e6-9681-9d7140758739.jpg)
